### PR TITLE
Type inference for usePlatform hook

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     "one-var": [2, {
       const: "never",
     }],
+    "@typescript-eslint/explicit-function-return-type": "off",
   },
   settings: {
     "import/resolver": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,23 +16,20 @@ import { UsePlatformPayload } from "./types";
  * So we should always check for the "MAC" string in order to detect
  * an Mac device
  */
-const isMac = navigator.platform.toUpperCase().includes("MAC");
+const isMac = navigator
+  .platform
+  .toUpperCase()
+  .includes("MAC");
 
 /**
  * Returns an object with user agent platform flags
  */
-const usePlatform = (): UsePlatformPayload => {
-  const payload = useMemo<UsePlatformPayload>(
-    () => ({
-      isIOS,
-      isMac,
-      isLinux: isLinux(),
-      isWindows: isWindows(),
-      isAndroid,
-    }), [],
-  );
-
-  return payload;
-};
+const usePlatform = () => useMemo<UsePlatformPayload>(() => ({
+  isIOS,
+  isMac,
+  isLinux: isLinux(),
+  isWindows: isWindows(),
+  isAndroid,
+}), []);
 
 export default usePlatform;


### PR DESCRIPTION
Let the TypeScript compiler infers the returning type for the `usePlatform` hook.

- Remove the returning type and let the compiler infers for us
- Remove the `payload` const and returns the value from `useMemo`
- Turn off the explicit function return type to let the compiler works on that